### PR TITLE
Fix over/under shoot for Gtk 3.16

### DIFF
--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -1360,6 +1360,16 @@ GtkScrolledWindow.frame {
     border-style: solid;
 }
 
+/* Drawn when content is dragged past boundaries */
+.overshoot {
+    background-color: transparent;
+}
+
+/* Drawn when there is more content */
+.undershoot {
+    background-color: transparent;
+}
+
 /*************
  * separator *
  *************/


### PR DESCRIPTION
Quick workaround to stop getting grey boxes over scrollable content in GTK-3.0 apps
